### PR TITLE
Colab dependency bug. Fixes mfranzon/yolo-training-template#6

### DIFF
--- a/notebooks/yolo_template.ipynb
+++ b/notebooks/yolo_template.ipynb
@@ -1,20 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "gpuType": "T4"
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "accelerator": "GPU"
-  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -33,16 +17,16 @@
       "cell_type": "code",
       "execution_count": 1,
       "metadata": {
-        "id": "jFpu15nn9TYM",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "id": "jFpu15nn9TYM",
         "outputId": "071f3219-783f-42d9-d32f-0a18a17be1ca"
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "\u001b[?25l   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/1.1 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.1/1.1 MB\u001b[0m \u001b[31m32.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
             "\u001b[?25h"
@@ -58,31 +42,36 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "XcYdPAlt9iD0"
+      },
+      "outputs": [],
       "source": [
         "import logging\n",
         "import os\n",
         "import yaml\n",
         "import kagglehub\n",
         "from ultralytics import YOLO\n",
+        "import cv2\n",
         "\n",
         "# Check if running in Google Colab\n",
         "try:\n",
         "    from google.colab.patches import cv2_imshow\n",
         "    IS_COLAB = True\n",
         "except ImportError:\n",
-        "    import cv2\n",
         "    IS_COLAB = False\n",
         "\n",
         "logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')"
-      ],
-      "metadata": {
-        "id": "XcYdPAlt9iD0"
-      },
-      "execution_count": 13,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "kFtYFAgG9liY"
+      },
+      "outputs": [],
       "source": [
         "def download_dataset(dataset_handle):\n",
         "    \"\"\"Download the Kaggle dataset.\"\"\"\n",
@@ -189,15 +178,15 @@
         "        exist_ok=True,\n",
         "    )\n",
         "    return results\n"
-      ],
-      "metadata": {
-        "id": "kFtYFAgG9liY"
-      },
-      "execution_count": 3,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {
+        "id": "7wp4lD1A9z7J"
+      },
+      "outputs": [],
       "source": [
         "def load_model(model_path):\n",
         "    \"\"\"Load the YOLO model from the specified path.\"\"\"\n",
@@ -283,15 +272,15 @@
         "            break\n",
         "    cap.release()\n",
         "    cv2.destroyAllWindows()"
-      ],
-      "metadata": {
-        "id": "7wp4lD1A9z7J"
-      },
-      "execution_count": 15,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "id": "ZfyM9HWT98Iq"
+      },
+      "outputs": [],
       "source": [
         "# Example regarding potholes\n",
         "\n",
@@ -305,15 +294,15 @@
         "project = 'runs/train'  # Project dir\n",
         "name = 'yolo_train'  # Experiment name\n",
         "\n"
-      ],
-      "metadata": {
-        "id": "ZfyM9HWT98Iq"
-      },
-      "execution_count": 5,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "DiwGD1sI-DXO"
+      },
+      "outputs": [],
       "source": [
         "dataset_path = download_dataset(dataset_handle)\n",
         "logging.info(f\"Dataset downloaded to: {dataset_path}\")\n",
@@ -324,29 +313,29 @@
         "results = train_model(yaml_path, epochs, imgsz, batch, device, project, name)\n",
         "logging.info(\"Training completed successfully\")\n",
         "\n"
-      ],
-      "metadata": {
-        "id": "DiwGD1sI-DXO"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 17,
+      "metadata": {
+        "id": "0_PgiU06A7bp"
+      },
+      "outputs": [],
       "source": [
         "model_path = 'runs/train/yolo_train/weights/best.pt'  # Path to trained model\n",
         "input_source = 'highway.mp4'  # 'path/to/image.jpg', 'path/to/video.mp4', or 'webcam'\n",
         "conf_thresh = 0.5  # Confidence threshold\n",
         "output_path = ''  # Optional: 'annotated.jpg' or 'annotated.mp4'"
-      ],
-      "metadata": {
-        "id": "0_PgiU06A7bp"
-      },
-      "execution_count": 17,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "UIC8nz1TBBXP"
+      },
+      "outputs": [],
       "source": [
         "model = load_model(model_path)\n",
         "input_lower = input_source.lower()\n",
@@ -359,12 +348,23 @@
         "else:\n",
         "    raise ValueError(\"Unsupported input type. Use image/video path or 'webcam'\")\n",
         "logging.info(\"Inference completed successfully\")"
-      ],
-      "metadata": {
-        "id": "UIC8nz1TBBXP"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
Moved `cv2` dependency import out of the try/except block so it will always import. 

This results in `cv2` always being imported, and therefore the cv2.function calls do not result in an exception.

_**note:** I'm not very familiar with .ipynb files and i'm not certain why i'm seeing so many additions/deletions in this diff. Please review carefully_